### PR TITLE
Respect aspect ratio in paper images

### DIFF
--- a/virtual/static/css/main.css
+++ b/virtual/static/css/main.css
@@ -47,7 +47,8 @@ body{font-family: 'Lato', sans-serif; background-color: rgba(236, 241, 246, 1)}
 
   .cards_img {margin-top: 20px;
               border-radius: 2px;
-              max-height: 100px;}
+              max-height: 100px;
+              object-fit: scale-down;}
   body .nav-pills .nav-link.active {
       background-color: #bed972;
   }

--- a/virtual/static/css/main.css
+++ b/virtual/static/css/main.css
@@ -47,7 +47,7 @@ body{font-family: 'Lato', sans-serif; background-color: rgba(236, 241, 246, 1)}
 
   .cards_img {margin-top: 20px;
               border-radius: 2px;
-              max-height: 100px;
+              max-height: 140px;
               object-fit: scale-down;}
   body .nav-pills .nav-link.active {
       background-color: #bed972;


### PR DESCRIPTION
![before and after](https://user-images.githubusercontent.com/505333/80371475-41470e80-8892-11ea-88ef-3b343675c91b.png)

I checked this looks okay even on very size-constrained paper tiles, such as this one:
![size-constrained-paper-tile](https://user-images.githubusercontent.com/505333/80370805-232cde80-8891-11ea-9985-5be5f1ca870b.png)
